### PR TITLE
Feature/log time

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import time
 
 from galaxy.proc_tools import process_iter
 from pathlib import Path
@@ -104,3 +105,15 @@ class AmazonGamesClient:
                 for proc in process_iter():
                     if proc.binary_path and game['program']['InstallLocation'] in proc.binary_path:
                         return True
+    
+    def _set_session_start(self) -> None:
+        ''' Sets the session start to the current time'''
+        self.start_time = time.time()
+
+    def _set_session_end(self) -> None:
+        ''' Sets the session end to the current time'''
+        self.end_time = time.time()
+
+    def _get_session_duration(self) -> int:
+        ''' Returns the duration of the game session in minutes as an int'''
+        return int(round((self.end_time - self.start_time) / 60))

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -139,17 +139,17 @@ class AmazonGamesPlugin(Plugin):
             with open(path, "w", encoding="utf-8") as game_times_file:
                 json.dump(data, game_times_file, indent=4)
 
-        for game in self._local_games_cache:
-            if game.id in data:
-                time_played = data.get(game.id).get("time_played")
-                last_time_played = data.get(game.id).get("last_time_played")
+        for game_id in self._local_games_cache.keys():
+            if game_id in data:
+                time_played = data.get(game_id).get("time_played")
+                last_time_played = data.get(game_id).get("last_time_played")
             else:
                 time_played = 0
                 last_time_played = None
-                data[game.id] = { "name": game.name, "time_played": 0, "last_time_played": None }
+                data[game_id] = { "time_played": 0, "last_time_played": None }
                 update_file = True
             
-            game_times[game.id] = GameTime(game.id, time_played, last_time_played)
+            game_times[game_id] = GameTime(game_id, time_played, last_time_played)
 
         if update_file == True:
             with open(path, "w", encoding="utf-8") as game_times_file:


### PR DESCRIPTION
I'm opening this PR with the feature I commented about in the issues. With this, Galaxy is able to record the time played of any game in amazon. The only drawback is that this only works fine if the client is set to automatically close. But since the client don't have any feature beside running games, I do believe this is the best way to let Galaxy handle things.